### PR TITLE
Add P3391 `constexpr std::format` to C++26

### DIFF
--- a/data/features_cpp26.yaml
+++ b/data/features_cpp26.yaml
@@ -1549,12 +1549,12 @@ features:
       - GCC 16
       - Clang 21 (partial)
 
-  - desc: '`constexpr std::format`'
+  - desc: '`constexpr` `std::format()`'
     paper: P3391
     lib: true
     ftm:
       - name: __cpp_lib_constexpr_format
-      - value: 202511L
+        value: 202511L
 
   - desc: 'Fix erroneous behaviour termination semantics for C++26'
     paper: P3684


### PR DESCRIPTION
According to [this blog post](https://herbsutter.com/2025/11/10/trip-report-november-2025-iso-c-standards-meeting-kona-usa/) P3391R2 has been adopted in the Kona 2025 meeting:

> We also adopted [P3391R2 “constexpr std::format”](https://isocpp.org/files/papers/P3391R2.html) by Barry Revzin. This makes it easier to apply string formatting to strings that need to be used at compile time, notably so they can be passed to static_assert which can accept std::string messages in C++26.