### PR TITLE
Add missing C++26 papers adopted at the Kona 2025 meeting

### DIFF
--- a/data/features_cpp26.yaml
+++ b/data/features_cpp26.yaml
@@ -1555,3 +1555,10 @@ features:
   - desc: "Standard library hardening should not use the 'observe' semantic"
     paper: P3878
     lib: true
+
+  - desc: 'Library Support for Expansion Statements'
+    paper: P1789
+    lib: true
+    ftm:
+      - name:  __cpp_lib_integer_sequence
+        value: 202511L


### PR DESCRIPTION
Changes according to [this blog post](https://herbsutter.com/2025/11/10/trip-report-november-2025-iso-c-standards-meeting-kona-usa/).