### PR TITLE
Mark P2697 “Interfacing std::bitset with std::string_view” as implemented by GCC 16

### DIFF
--- a/data/features_cpp26.yaml
+++ b/data/features_cpp26.yaml
@@ -840,6 +840,7 @@ features:
     support:
       - Clang 18
       - Xcode 16
+      - GCC 16
     ftm:
       - name: __cpp_lib_bitset
         value: 202306L


### PR DESCRIPTION
> New std::stringstream and std::bitset member functions accepting std::string_view arguments, thanks to Nathan Myers.

https://gcc.gnu.org/gcc-16/changes.html#libstdcxx