### PR TITLE
Update MSVC conformance status for C++11-20

### DIFF
--- a/features_cpp14.yaml
+++ b/features_cpp14.yaml
@@ -372,10 +372,12 @@ features:
         value: 201402L
 
   - desc: "`std::shared_timed_mutex`"
-    paper: N3659
+    paper:
+      - N3659
+      - N3891
     lib: true
     support:
-      - GCC 4.9
+      - GCC 5
       - Clang 3.5
       - MSVC 19.0
       - Xcode

--- a/features_cpp17.yaml
+++ b/features_cpp17.yaml
@@ -737,7 +737,7 @@ features:
     support:
       - GCC 7
       - Clang 4
-      - MSVC 19.10
+      - MSVC 19.11
       - Xcode 10
     ftm:
       - name: __cpp_lib_string_view
@@ -751,7 +751,7 @@ features:
     support:
       - GCC 7
       - Clang 4
-      - MSVC 19.11
+      - MSVC 19.10
       - Xcode 10
     ftm:
       - name: __cpp_lib_any
@@ -901,7 +901,7 @@ features:
       - MSVC 19.14 (partial)
       - MSVC 19.15 (partial)
       - MSVC 19.16 (partial)
-      - MSVC 19.23
+      - MSVC 19.24
       - Xcode 10 (partial)
     hints:
       - target: GCC 8

--- a/features_cpp20.yaml
+++ b/features_cpp20.yaml
@@ -17,7 +17,7 @@ features:
       - GCC 10 (partial)
       - GCC 12
       - Clang 9
-      - MSVC 19.21
+      - MSVC 19.25
       - Xcode 12
     hints:
       - target: GCC 8
@@ -429,7 +429,9 @@ features:
         value: 202002L
 
   - desc: "Coroutines"
-    paper: P0912
+    paper:
+      - P0912
+      - LWG3393
     support:
       - GCC 10 (hint)
       - Clang 8 (partial)
@@ -522,7 +524,7 @@ features:
     support:
       - GCC 10
       - Clang
-      - MSVC 19.0
+      - MSVC 19.26
       - Xcode
 
   - desc: "`<=>` `!=` `==`"
@@ -1614,7 +1616,7 @@ features:
     support:
       - GCC 11
       - Clang 11
-      - MSVC 19.29
+      - MSVC 19.28
       - Xcode (hint)
     hints:
       - target: Xcode


### PR DESCRIPTION
Partially fix #59, except

paper | status | lib | ver | comment
-- | -- | -- | -- | --
N3664 | Yes -> No | False | 14 | Depend on how we treat N/A
P0063 | 19.0 (partial) -> 19.28 | True | 17 | Why 19.28?
P1957 | - 19.27 | False | 20 | Missing