### PR TITLE
Update MSVC conformance status for C++23-26

### DIFF
--- a/features_cpp23.yaml
+++ b/features_cpp23.yaml
@@ -51,7 +51,7 @@ features:
       - Clang 13 (partial)
       - Clang 14
       - MSVC 19.21 (hint)
-      - MSVC 19.32
+      - MSVC 19.44
       - Xcode 14
     hints:
       - target: Clang 13
@@ -80,7 +80,7 @@ features:
     support:
       - GCC
       - Clang
-      - MSVC
+      - MSVC 19.44
       - Xcode
 
   - desc: "Explicit object member functions (deducing `this`)"
@@ -277,7 +277,7 @@ features:
     support:
       - GCC 13
       - Clang 15
-      - MSVC 19
+      - MSVC 19.0
       - Xcode 15
 
   - desc: "`static operator[]`"
@@ -368,7 +368,7 @@ features:
     support:
       - GCC 12
       - Clang 19
-      - MSVC 19.32
+      - MSVC 19.50
       - Xcode 16.4
 
   - desc: "Relax requirements on `wchar_t` to match existing practices"
@@ -376,7 +376,7 @@ features:
     support:
       - GCC
       - Clang
-      - MSVC
+      - MSVC 19.44
       - Xcode 15
 
   - desc: "Using unknown pointers and references in constant expressions"
@@ -628,7 +628,7 @@ features:
     support:
       - GCC 13
       - Clang 15 (partial)
-      - MSVC 19.33
+      - MSVC 19.37
       - Xcode 14.3
     hints:
       - target: Clang 15
@@ -709,7 +709,7 @@ features:
     support:
       - GCC 12
       - Clang 14
-      - MSVC 19.25
+      - MSVC 19.31
       - Xcode 14.3
 
   - desc: "Require `std::span` and `std::basic_string_view` to be [TriviallyCopyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable)"
@@ -718,7 +718,7 @@ features:
     support:
       - GCC
       - Clang
-      - MSVC
+      - MSVC 19.31
       - Xcode
 
   - desc: 'Clarifying the status of the "C headers"'
@@ -779,7 +779,7 @@ features:
       - GCC 13 (partial)
       - GCC 14
       - Clang 21 (partial)
-      - MSVC 19.50 (partial)
+      - MSVC 19.51 (partial)
       - Xcode 16.3
     hints:
       - target: GCC 13
@@ -1368,7 +1368,7 @@ features:
     support:
       - GCC 16
       - Clang 20
-      - MSVC 19.50 (partial)
+      - MSVC 19.51 (partial)
       - Xcode 26
     hints:
       - target: MSVC 19.50


### PR DESCRIPTION
I have checked the reference correctness of all features for MSVC. Theoretically, the implementation time of any feature can be found in the reference list below.

- [Microsoft C/C++ language conformance](https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance)
- [STL Changelog](https://github.com/microsoft/STL/wiki/Changelog)
- References for features not included above
    - [Support For C++11/14/17 Features (Modern C++)](https://learn.microsoft.com/en-us/previous-versions/hh567368(v=vs.140)) includes C++11 core language features
    - [Visual C++ What's New 2003 through 2015](https://learn.microsoft.com/en-us/cpp/porting/visual-cpp-what-s-new-2003-through-2015) includes C++11 N1913
    - [C++14/17 Features and STL Fixes in VS "15" Preview 5](https://devblogs.microsoft.com/cppblog/c1417-features-and-stl-fixes-in-vs-15-preview-5/) includes C++14 LWG2112, LWG2247 and LWG2285, and C++17 LWG2296
    - [STL Features and Fixes in VS 2017 15.8](https://devblogs.microsoft.com/cppblog/stl-features-and-fixes-in-vs-2017-15-8/) includes C++17 LWG2911
    - [C++ Language Updates in MSVC in Visual Studio 2022 17.13](https://devblogs.microsoft.com/cppblog/msvc-compiler-updates-in-visual-studio-2022-version-17-13/) includes C++23 P2242
    - [C++ Language Updates in MSVC in Visual Studio 2022 17.14](https://devblogs.microsoft.com/cppblog/c-language-updates-in-msvc-in-visual-studio-2022-17-14/) includes C++23 P2589
    - [C++ Language Updates in MSVC Build Tools v14.50](https://devblogs.microsoft.com/cppblog/c-language-updates-in-msvc-build-tools-v14-50/) includes C++23 P2797