### PR TITLE
Add more toolchains: OpenWatcom (owcc) and the Tiny C Compiler (tcc)

### DIFF
--- a/features_c11.yaml
+++ b/features_c11.yaml
@@ -7,6 +7,7 @@ features:
       - Clang 3.1
       - MSVC 14.28
       - Xcode 16.1
+      - TinyCC
   - desc: "Generic selection (`_Generic`)"
     paper: N1441
     support:
@@ -14,6 +15,7 @@ features:
       - Clang 3.1
       - MSVC 14.27
       - Xcode 16.1
+      - TinyCC
   - desc: "Anonymous structures and unions"
     paper: N1444
     support:
@@ -58,6 +60,8 @@ features:
       - Clang 3.3
       - MSVC 14.28
       - Xcode 16.1
+      - owcc
+      - TinyCC
   - desc: "Unicode support (`<uchar.h>`, `u/U` prefixes)"
     paper: N1487
     support:

--- a/features_c23.yaml
+++ b/features_c23.yaml
@@ -84,6 +84,8 @@ features:
       - Clang 9
       - MSVC 14.0 (hint)
       - Xcode
+      - owcc
+      - TinyCC
     hints:
       - target: GCC 4.3
         msg: "Supported as an extension."
@@ -150,6 +152,8 @@ features:
       - GCC
       - Clang
       - Xcode 16.1
+      - owcc
+      - TinyCC
   - desc: "Bit-precise integer types (`_BitInt`)"
     paper: N2763
     support:
@@ -178,6 +182,7 @@ features:
       - Clang
       - MSVC 14.11
       - Xcode
+      - TinyCC
   - desc: "Identifier Syntax using Unicode Standard Annex 31"
     paper: N2836
     support:

--- a/features_c99.yaml
+++ b/features_c99.yaml
@@ -12,6 +12,8 @@ features:
       - GCC
       - Clang
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "`//` comments"
     paper: N644
     support:
@@ -19,6 +21,8 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "`restrict` pointers"
     paper: N448
     support:
@@ -26,6 +30,8 @@ features:
       - Clang
       - MSVC (partial)
       - Xcode
+      - owcc
+      - TinyCC
     hints:
       - target: MSVC
         msg: "Requires /std:c11 or later."
@@ -47,12 +53,15 @@ features:
       - GCC 3
       - Clang
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "[Variable-length array](https://en.cppreference.com/w/c/language/array.html#Variable-length_arrays) (VLA) types"
     paper: N683
     support:
       - GCC
       - Clang
       - Xcode
+      - TinyCC
   - desc: "Variably-modified (VM) types"
     paper: N2778
     support:
@@ -80,6 +89,8 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "Hexadecimal [floating constants](https://en.cppreference.com/w/c/language/floating_constant.html)"
     paper: N308
     support:
@@ -87,6 +98,8 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "[Compound literals](https://en.cppreference.com/w/c/language/compound_literal.html)"
     paper: N716
     support:
@@ -111,6 +124,8 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "Declarations and statements in mixed order"
     paper: N740
     support:
@@ -118,12 +133,16 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "_init-statement_ in `for` loops"
     support:
       - GCC
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "`inline` functions"
     paper: N741
     support:
@@ -131,6 +150,8 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "Predefined variable `__func__`"
     paper: N611
     support:
@@ -138,6 +159,8 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "Cvr-qualifiers and `static` in `[]` within function declarations"
     support:
       - GCC 3.1
@@ -150,6 +173,8 @@ features:
       - Clang
       - MSVC
       - Xcode
+      - owcc
+      - TinyCC
   - desc: "`_Pragma` preprocessor operator"
     paper: N634
     support:
@@ -157,6 +182,7 @@ features:
       - Clang
       - MSVC (partial)
       - Xcode
+      - owcc
     hints:
       - target: MSVC
         msg: "Requires /std:c11 or later."

--- a/toolchains.yaml
+++ b/toolchains.yaml
@@ -29,6 +29,18 @@ infos:
     refs:
       - "https://developer.apple.com/xcode/cpp/"
 
+  - name: owcc
+    desc: This applies to Watcom / OpenWatcom in general, not any specific version.
+    released: 1984
+    refs:
+      - "https://github.com/open-watcom/open-watcom-v2/releases"
+
+  - name: TinyCC
+    desc: This applies to the Tiny C Compiler in general, not any specific version.
+    released: 2001
+    refs:
+      - "https://download.savannah.nongnu.org/releases/tinycc/"
+
   - name: GCC 3.1
     released: May, 2002
     refs:
@@ -1818,3 +1830,71 @@ infos:
     apple_clang: 17.0.0 (clang-1700.6.3.2)
     refs:
       - https://developer.apple.com/documentation/xcode-release-notes/xcode-26_2-release-notes
+
+  - name: owcc 1.0
+    released: January 28, 2003
+
+  - name: owcc 1.1
+    released: August 12, 2003
+
+  - name: owcc 1.2
+    released: January 7, 2004
+
+  - name: owcc 1.3
+    released: August 3, 2004
+
+  - name: owcc 1.4
+    released: December 14, 2005
+
+  - name: owcc 1.5
+    released: April 26, 2006
+
+  - name: owcc 1.6
+    released: December 15, 2006
+
+  - name: owcc 1.7
+    released: August 18, 2007
+
+  - name: owcc 1.7a
+    released: October 23, 2007
+
+  - name: owcc 1.8
+    released: February 21, 2009
+
+  - name: owcc 1.9
+    desc: The latest Open Watcom 1.x release by openwatcom.org
+    released: June 2, 2010
+
+  - name: owcc 2.0
+    desc: Rolling release of the Open Watcom v2 fork
+    released: January 23, 2026
+    refs:
+      - "https://github.com/open-watcom/open-watcom-v2/releases"
+      - "https://github.com/open-watcom/open-watcom-v2.git"
+
+  - name: TinyCC 0.9.24
+    released: March 31, 2008
+    refs:
+      - "https://download.savannah.nongnu.org/releases/tinycc/"
+
+  - name: TinyCC 0.9.25
+    released: May 18, 2009
+    refs:
+      - "https://download.savannah.nongnu.org/releases/tinycc/"
+
+  - name: TinyCC 0.9.26
+    released: February 15, 2013
+    refs:
+      - "https://download.savannah.nongnu.org/releases/tinycc/"
+
+  - name: TinyCC 0.9.27
+    desc: This applies to the latest released Tiny C Compiler
+    released: December 17, 2017
+    refs:
+      - "https://download.savannah.nongnu.org/releases/tinycc/"
+
+  - name: TinyCC 0.9.28rc
+    desc: This applies to the latest TinyCC snapshoot
+    released: TBD
+    refs:
+      - "https://repo.or.cz/tinycc.git"


### PR DESCRIPTION
Thanks for cppstat.

I will add the OpenWatcom and tcc features later, when this is accepted



Why OpenWatcom:
* has a long History: Started as a comercial compiler and used in most DOS-games in the 90th
* is Open Source since 2003 and still under development: https://github.com/open-watcom/open-watcom-v2.git
* is self contained with Assemblers, compilers for C, C++ and Fortran, a libtool, a linker and runtime libraries
* includes also an IDE, a Debugger, a profiler and many other tools
* supports many common and unusual targets: Linux, Windows, DOS, OS/2, RDOS, Netware

Why TinyCC:
* is small and can compile hyper fast
* allows scripting of C source files
* is an assembler, a C Compiler, a library Tool and a linker in one Program
* is used as fast backend in other languages
* is still under development: https://repo.or.cz/tinycc.git
