### PR TITLE
Fix incorrect version changes from MSVC to MSVC build tools

### DIFF
--- a/features_cpp11.yaml
+++ b/features_cpp11.yaml
@@ -28,7 +28,7 @@ features:
     support:
       - GCC 4.3
       - Clang
-      - MSVC 14.0
+      - MSVC 8.0
       - Xcode
 
   - desc: "Extended `friend` declarations"
@@ -44,7 +44,7 @@ features:
     support:
       - GCC
       - Clang
-      - MSVC 14.0
+      - MSVC 8.0
       - Xcode
 
   - desc: "[`auto`](https://cppreference.com/w/cpp/language/auto.html)"
@@ -74,7 +74,7 @@ features:
     support:
       - GCC 3.3
       - Clang
-      - MSVC 12.0
+      - MSVC 6.0
       - Xcode
 
   - desc: "`constexpr`"


### PR DESCRIPTION
This issue was introduced in 404dd00.