### PR TITLE
fix(data): remove incorrect Clang support for P0288 (move_only_function)

### DIFF
--- a/features_cpp23.yaml
+++ b/features_cpp23.yaml
@@ -526,7 +526,6 @@ features:
     lib: true
     support:
       - GCC 12
-      - Clang 17
       - MSVC 14.32
     ftm:
       - name: __cpp_lib_move_only_function


### PR DESCRIPTION
### Problem
The data currently indicates that **Clang 17+** supports **P0288R9 (`std::move_only_function`)**. 

However, since the Clang column on this site tracks **libc++** status for library features, this is a false positive. `libc++` has not yet implemented this feature in its mainline branches (including the latest v23 trunk).

### Evidence & Root Cause
I have prepared a live reproduction on Compiler Explorer to demonstrate why the previous check likely succeeded while the actual feature is missing:

**🔗 Godbolt Link:** https://godbolt.org/z/a7eTbxKzj

* **Top Pane (Clang Trunk + `-stdlib=libc++`)**: ❌ Fails to compile. This confirms that even the bleeding-edge `libc++` does not yet contain the definition for `move_only_function`.
* **Bottom Pane (Clang 17 + default libstdc++)**: ✅ Succeeds. On Linux, `clang++` defaults to GCC's `libstdc++`. Since GCC 12+ implemented this feature, it masks the missing support in `libc++`.

### References
* **LLVM Upstream Status**: The implementation is still a Work-In-Progress and has not been merged. 
  * See PR: [llvm/llvm-project#94670](https://github.com/llvm/llvm-project/pull/94670)

### Changes
- Removed `Clang 17` from the `support` list for P0288 in `features_cpp23.yaml`.