### PR TITLE
Mark Clang 18/19 support for P0847 and P2718 as partial

### DIFF
--- a/features_cpp23.yaml
+++ b/features_cpp23.yaml
@@ -411,11 +411,17 @@ features:
     content: deducing-this.md
     support:
       - GCC 14
-      - Clang 18
-      - Clang 19
+      - Clang 18 (partial)
+      - Clang 19 (partial)
+      - Clang 20
       - MSVC 14.32
       - MSVC 14.43
       - Xcode 16.3
+    hints:
+      - target: Clang 18
+        msg: "Experimental support. Lacks P2797 and the FTM `__cpp_explicit_this_parameter`. Its support can be tested with `__has_extension(cxx_explicit_this_parameter)`."
+      - target: Clang 19
+        msg: "Completes core language support (P2797), but still lacks the FTM `__cpp_explicit_this_parameter`."
     ftm:
       - name: __cpp_explicit_this_parameter
         value: 202110L
@@ -1433,8 +1439,12 @@ features:
     paper: [P2644, P2718]
     support:
       - GCC 15
-      - Clang 19
+      - Clang 19 (partial)
+      - Clang 20
       - Xcode 16.3
+    hints:
+      - target: Clang 19
+        msg: "Misses lifetime extension of temporaries in `mem-default-init` cases."
     ftm:
       - name: __cpp_range_based_for
         value: 202211L


### PR DESCRIPTION
### Description

This PR updates the support status of **Clang 18** and **Clang 19** for two C++23 features to `(partial)` and adds corresponding hints to help developers avoid unexpected compilation errors or undefined behavior.

While Clang's release notes mentioned implementations for these features, there are critical missing parts in generic programming and edge cases until Clang 20.

#### 1. P0847: Explicit object member functions (Deducing `this`)
- **Clang 18**: Implemented core P0847 but lacks P2797R0. Also, the feature test macro `__cpp_explicit_this_parameter` was intentionally hidden.
- **Clang 19**: Completes core language support (P2797R0), but still lacks the FTM.  (The FTM is finally added in Clang 20 via [llvm/llvm-project#107451](https://github.com/llvm/llvm-project/pull/107451)).
- **Added hints**: Clarified the missing FTM and provided the `__has_extension(cxx_explicit_this_parameter)` workaround for developers relying on `#ifdef`.

#### 2. P2718: Extending the lifetime of temporaries in range-based `for`
- **Clang 19**: Claimed support but actually missed the lifetime extension for temporaries in `mem-default-init` cases, which can lead to silent Undefined Behavior. Clang 20 release notes explicitly state they "now fully support" it by covering this missing case.
- **Added hints**: Warns users about the `mem-default-init` gap in Clang 19.

| Feature | Clang 18 | Clang 19 | Clang 20 |
|---------|----------|----------|----------|
| P0847 + FTM | ❌ Core only, FTM hidden | ❌ Core + P2797R0, FTM missing | ✅ Full |
| P2718 + mem-default-init | ❌ | ❌ Silent UB possible | ✅ Full |

### Changes Made
- Updated `support` lists for `P0847` and `P2718` in `features_cpp23.yaml` to include `(partial)` for Clang 18/19.
- Added specific, concise `hints` for these partial implementations.

### References
- Clang 18 Release Notes: https://releases.llvm.org/18.1.0/tools/clang/docs/ReleaseNotes.html#c-23-feature-support
- Clang 19 Release Notes: https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#c-23-feature-support
- Clang 20 Release Notes: https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#c-23-feature-support