### PR TITLE
Add and correct information on P1383

### DIFF
--- a/content/more-constexpr-cmath.md
+++ b/content/more-constexpr-cmath.md
@@ -1,0 +1,27 @@
+---
+execute: false
+---
+
+## What It Does
+
+Most functions in the `<cmath>` and `<complex>` headers are made `constexpr`.
+
+## Why It Matters
+
+Historically, while arithmetic expressions such as addition and multiplication
+between floating-point operands could be used in constant expressions,
+common mathematical functions such as `std::sqrt` or `std::pow` couldn't be.
+This meant that some computations had to be done unnecessarily at runtime,
+or the user had to re-implement a `constexpr` version
+of the `<cmath>`functions themselves.
+The same applies to the corresponding functions in `<complex>`.
+
+## Example
+
+```cpp
+#include <cmath>
+#include <complex>
+
+constexpr double sqrt_10 = std::sqrt(10);
+constexpr std::complex<double> i = std::sqrt(std::complex<double>(-1));
+```

--- a/features_cpp26.yaml
+++ b/features_cpp26.yaml
@@ -309,8 +309,10 @@ features:
 
   - desc: "More constexpr for `<cmath>` and `<complex>`"
     paper: P1383
+    summary: "More mathematical functions are now `constexpr`, such as `std::sqrt`."
+    content: more-constexpr-cmath.md
     lib: true
-    support: [GCC 4.6]
+    support: [GCC 4.6 (partial)]
     ftm:
       - name: __cpp_lib_constexpr_cmath
         value: 202306L


### PR DESCRIPTION
The GCC 4.6 support is incorrect. At least the `<complex>` changes are missing. https://gcc.gnu.org/wiki/LibstdcxxTodo marks the feature as an outstanding TODO.

It is true that some functions (such as `std::sqrt`) work with non-complex operands already, but that doesn't mean there is a full implementation.