### PR TITLE
Add GCC 16 support for P3836

### DIFF
--- a/features_cpp26.yaml
+++ b/features_cpp26.yaml
@@ -1586,7 +1586,7 @@ features:
   - desc: "Make `std::optional<T&>` trivially copyable"
     paper: P3836
     lib: true
-    support: [Clang 22]
+    support: [GCC 16, Clang 22]
 
   - desc: "When Do You Know `execution::connect()` Doesn’t Throw?"
     paper: P3388


### PR DESCRIPTION
This is already marked as done in https://gcc.gnu.org/wiki/LibstdcxxTodo

GCC 16 added support for `std::optional<T&>`; I'm pretty sure it was trivially copyable from the start.