### PR TITLE
Add GCC 16 support for P3663

### DIFF
--- a/features_cpp26.yaml
+++ b/features_cpp26.yaml
@@ -1582,6 +1582,7 @@ features:
   - desc: "Future-proof `submdspan_mapping`"
     paper: P3663
     lib: true
+    support: [GCC 16]
 
   - desc: "Make `std::optional<T&>` trivially copyable"
     paper: P3836


### PR DESCRIPTION
It's marked as done in https://gcc.gnu.org/wiki/LibstdcxxTodo