### PR TITLE
Add GCC 16 support for P3913

### DIFF
--- a/features_cpp26.yaml
+++ b/features_cpp26.yaml
@@ -1643,3 +1643,4 @@ features:
   - desc: "Optimize for `std::optional` in range adaptors"
     paper: P3913
     lib: true
+    support: [GCC 16]


### PR DESCRIPTION
It's marked as done in https://gcc.gnu.org/wiki/LibstdcxxTodo