### PR TITLE
Add GCC 16 support for P3641

### DIFF
--- a/features_cpp26.yaml
+++ b/features_cpp26.yaml
@@ -1377,6 +1377,7 @@ features:
     ftm:
       - name: __cpp_lib_observable_checkpoint
         value: 202506L
+    support: [GCC 16]
 
   - desc: "`std::string::subview()`"
     paper: P3044


### PR DESCRIPTION
It's not officially documented on the TODO list yet, but it looks like libstdc++ called it `std::observable_checkpoint` from the start: https://github.com/gcc-mirror/gcc/blob/debb3d46e4f3161595fc9bd88c59cf0a07d0baf7/libstdc%2B%2B-v3/include/std/utility#L180