### PR TITLE
Improve P1789 description

### DIFF
--- a/content/expansion-statements-library-support.md
+++ b/content/expansion-statements-library-support.md
@@ -62,9 +62,9 @@ int main() {
     auto tup = std::tuple{1, 3.14, "hello"};
     auto tup2 = std::tuple{2, 3.14, "hell"};
 
-    assert(not is_eq_iile(tup, tup2));
-    assert(not is_eq_fold(tup, tup2));
-    assert(not is_eq_template_for(tup, tup2));
+    assert(!is_eq_iile(tup, tup2));
+    assert(!is_eq_fold(tup, tup2));
+    assert(!is_eq_template_for(tup, tup2));
 
     assert(is_eq_iile(tup, tup));
     assert(is_eq_fold(tup, tup));


### PR DESCRIPTION
The previous description did not capture the intended use for this feature properly. There is not much point in introducing an index sequence to operate on a single pack/tuple-like - it's more interesting for operating on more than one of those things at the same time.

I've changed the example to a simple tuple comparison - this should showcase how this change can improve pre-C++26 code.

Additionally a few little nitpicks in the "What it does" section:
- we don't specialize `get`, we provide ADL-discoverable overloads
- the point of introducing packs via structured binding is to stay within the same function scope (this matters because of P3096, see paper)