### PR TITLE
Update features_cpp26.yaml for P2875 in GCC

### DIFF
--- a/features_cpp26.yaml
+++ b/features_cpp26.yaml
@@ -645,7 +645,7 @@ features:
   - desc: "Undeprecate `std::polymorphic_allocator::destroy()` for C++26"
     paper: P2875
     lib: true
-    support: [Clang 15, MSVC 14.41]
+    support: [GCC 14.3, Clang 15, MSVC 14.41]
 
   - desc: "Remove deprecated strstreams from C++26"
     paper: P2867


### PR DESCRIPTION
Implemented for 15.1.0 by https://github.com/gcc-mirror/gcc/commit/c3e237338eb7ffc90f3cc8d32a3971d17f6d0b31 and backported for GCC 14.3.0 and 13.4.0.

Since all releases >= 14.3.0 have the change, I chose 14.3 for the value in the table.