### PR TITLE
gcc supports C23 empty initializers fully

### DIFF
--- a/features_c23.yaml
+++ b/features_c23.yaml
@@ -205,12 +205,10 @@ features:
     paper: N2900
     content: c-empty-init.md
     support:
-      - GCC 13 (partial)
+      - GCC 13
       - Clang (partial)
       - Xcode (partial)
     hints:
-      - target: GCC 13
-        msg: "Supported as an extension. Missing support for scalars and variable-length arrays (VLAs)."
       - target: Clang
         msg: "Supported as an extension. Missing support for scalars and variable-length arrays (VLAs)."
       - target: Xcode


### PR DESCRIPTION
See here: https://godbolt.org/z/c65f1shx1