### PR TITLE
Remove 'auto' placeholder type entry

### DIFF
--- a/features_c2y.yaml
+++ b/features_c2y.yaml
@@ -258,9 +258,6 @@ features:
       - GCC 16
       - Xcode 16.4
 
-  - desc: "`auto` as placeholder type for parameters"
-    paper: N3472
-
   - desc: "Slay Some Earthly Demons XIII"
     paper: N3478
     support:


### PR DESCRIPTION
This feature is not voted in as of March 2026.