### PR TITLE
Empty initialization in GCC

### DIFF
--- a/features_c23.yaml
+++ b/features_c23.yaml
@@ -209,8 +209,8 @@ features:
       - Clang (partial)
       - Xcode (partial)
     hints:
-      - target: GCC
-        mssg: "Partially supported as an extension before."
+      - target: GCC 13
+        msg: "Partially supported as an extension before."
       - target: Clang
         msg: "Supported as an extension. Missing support for scalars and variable-length arrays (VLAs)."
       - target: Xcode


### PR DESCRIPTION
Somehow this got lost. I also added a hint to indicate that it was partially supported before.