### PR TITLE
Update conformance for MSVC 14.51

### DIFF
--- a/features_cpp23.yaml
+++ b/features_cpp23.yaml
@@ -490,6 +490,7 @@ features:
       - GCC 10
       - Clang
       - Xcode
+      - MSVC 14.51
 
   - desc: "Fixing locale handling in chrono formatters"
     paper: P2372
@@ -683,6 +684,7 @@ features:
   - desc: "`constexpr` for `<cmath>` and `<cstdlib>`"
     paper: P0533
     lib: true
+    support: [MSVC 14.52]
     ftm:
       - name: __cpp_lib_constexpr_cmath
         value: 202202L
@@ -855,6 +857,7 @@ features:
       - GCC 13
       - Clang 14
       - Xcode 15
+      - MSVC 14.51
 
   - desc: "Labels at the end of compound statements"
     paper: P2324
@@ -863,6 +866,7 @@ features:
       - GCC 13
       - Clang 16
       - Xcode 16
+      - MSVC 14.51
 
   - desc: "Delimited escape sequences"
     paper: P2290
@@ -880,6 +884,7 @@ features:
       - GCC 13
       - Clang 19
       - Xcode 16.3
+      - MSVC 14.51
     ftm:
       - name: __cpp_constexpr
         value: 202207L
@@ -903,6 +908,7 @@ features:
       - GCC 13
       - Clang 15
       - Xcode 15
+      - MSVC 14.51
     ftm:
       - name: __cpp_named_character_escapes
         value: 202207L
@@ -960,7 +966,7 @@ features:
   - desc: "Class template argument deduction from inherited constructors"
     paper: P2582
     summary: "Class template argument deduction works with inherited constructors."
-    support: [GCC 14]
+    support: [GCC 14, MSVC 14.51]
 
   - desc: "Attribute `[[assume]]`"
     paper: P1774
@@ -969,6 +975,7 @@ features:
       - GCC 13
       - Clang 19
       - Xcode 16.3
+      - MSVC 14.51
 
   - desc: "Support for UTF-8 as a portable source file encoding"
     paper: P2295
@@ -1420,6 +1427,7 @@ features:
       - GCC 13
       - Clang 16
       - Xcode 16
+      - MSVC 14.51
     ftm:
       - name: __cpp_constexpr
         value: 202211L
@@ -1431,6 +1439,7 @@ features:
       - GCC 14
       - Clang 17
       - Xcode 16
+      - MSVC 14.52
     ftm:
       - name: __cpp_consteval
         value: 202211L
@@ -1449,6 +1458,7 @@ features:
       - Clang 19 (partial)
       - Clang 20
       - Xcode 16.3
+      - MSVC 14.51
     hints:
       - target: Clang 19
         msg: "Misses lifetime extension of temporaries in `mem-default-init` cases."


### PR DESCRIPTION
https://devblogs.microsoft.com/cppblog/c23-support-in-msvc-build-tools-14-51/

Note that P2362 and [P2644, P2718] weren't mentioned in this blog.

But according to

> At this point, we have two remaining features for completion of support for C++23. Both of these features are in-progress and will land in an upcoming MSVC Build Tools 14.52 Preview update.
> [P2564R3](https://wg21.link/p2564r3) consteval needs to propagate up
> [P0533R9](https://wg21.link/p0533r9) constexpr <cmath>

I think all other C++23 features should have been implemented in 14.51.