### PR TITLE
Fix status for libc++ support for P0769

### DIFF
--- a/features_cpp20.yaml
+++ b/features_cpp20.yaml
@@ -648,9 +648,14 @@ features:
     lib: true
     support:
       - GCC 10
-      - Clang 12
+      - Clang 12 (partial)
       - MSVC 14.21
-      - Xcode 13
+      - Xcode 13 (partial)
+    hints:
+      - target: Clang 12
+        msg: "The parallel versions (`std::execution::par`) are not implemented yet. ([Issue](https://github.com/llvm/llvm-project/issues/104095))"
+      - target: Xcode 13
+        msg: "The parallel versions (`std::execution::par`) are not implemented yet. ([Issue](https://github.com/llvm/llvm-project/issues/104095))"
     ftm:
       - name: __cpp_lib_shift
         value: 201806L


### PR DESCRIPTION
Like P0040R3, libc++ is also lacking parallel versions of `std::shift_left`/`std::shift_right`. See llvm/llvm-project#104095.

I've just fixed the [status page (template) on cppreference](https://en.cppreference.com/Template:cpp/compiler_support/20).