### PR TITLE
Revert "Add hint to Clang 22 support for P1789"

### DIFF
--- a/features_cpp26.yaml
+++ b/features_cpp26.yaml
@@ -1631,13 +1631,10 @@ features:
     summary: "Specializes `std::tuple_size`, `std::tuple_element`, and `std::get` for `std::integer_sequence` to make it usable in expansion statements and structured bindings."
     content: expansion-statements-library-support.md
     lib: true
-    support: [Clang 22 (hint), GCC 16]
+    support: [Clang 22, GCC 16]
     ftm:
       - name: __cpp_lib_integer_sequence
         value: 202511L
-    hints:
-      - target: Clang 22
-        msg: "Currently not usable due to pending core language changes. See [CWG3135](https://cplusplus.github.io/CWG/issues/3135.html) for details."
     keywords: ["reflection"]
 
   - desc: "Missing deduction guide from `simd::mask` to `simd::vec`"


### PR DESCRIPTION
This reverts commit 3e966ebc7801b87698e70e9d565892d3fe71981b.

I've implemented CWG3135 for clang 23, this note is no longer necessary. I have not updated this to say clang 23 instead of clang 22 since the library feature was implemented in libc++ 22.